### PR TITLE
Skip link dereferencing on Windows

### DIFF
--- a/prance/util/fs.py
+++ b/prance/util/fs.py
@@ -58,7 +58,12 @@ def canonical_filename(filename):
     path = os.path.abspath(path)
     try:
       p = os.path.dirname(path)
-      path = os.path.join(p, os.readlink(path))
+      # os.readlink doesn't exist in windows python2.7
+      try:
+        deref_path = os.readlink(path)
+      except AttributeError:
+        return path
+      path = os.path.join(p, deref_path)
     except OSError:
       return path
 


### PR DESCRIPTION
I ran into an issue trying to resolve references using python 2.7 on Windows. I tracked it down to `os.readlink()` not being available on windows in python 2.7. I added a check to skip this on nt machines since they don't have symbolic links.