### PR TITLE
Fix windows support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,11 @@ references, in case you prefer that.
     parser = BaseParser('path/to/my/swagger.yaml')
     parser.specification  # contains specs as a dict still containing JSON references
 
+On Windows, the code react correctly if you pass posix-like paths
+(``/c:/swagger``) or if the path is relative.  If you pass absolute
+windows path (like ``c:\swagger.yaml``), you can use
+`prance.util.fs.abspath` to convert them.
+
 URLs can also be parsed:
 
 .. code:: python

--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -21,7 +21,12 @@ from swagger_spec_validator.common import SwaggerValidationError  # noqa: F401
 from . import mixins
 
 # Placeholder for when no URL is specified for the main spec file
-_PLACEHOLDER_URL = 'file:///__placeholder_url__.yaml'
+import sys
+if sys.platform == "win32":
+  # Placeholder must be absolute
+  _PLACEHOLDER_URL = 'file:///c:/__placeholder_url__.yaml'
+else:
+  _PLACEHOLDER_URL = 'file:///__placeholder_url__.yaml'
 
 
 class BaseParser(mixins.YAMLMixin, mixins.JSONMixin, object):
@@ -54,8 +59,9 @@ class BaseParser(mixins.YAMLMixin, mixins.JSONMixin, object):
     self.url = None
     if url:
       from .util.url import absurl
+      from .util.fs import abspath
       import os
-      self.url = absurl(url, os.getcwd())
+      self.url = absurl(url, abspath(os.getcwd()))
     else:
       self.url = _PLACEHOLDER_URL
 

--- a/prance/cli.py
+++ b/prance/cli.py
@@ -78,10 +78,15 @@ def validate(resolve, strict, output_file, urls):
     raise click.UsageError('If --output-file is given, only one input URL '
         'is allowed!')
 
+  import os.path
+  from prance.util import fs
   # Process files
   for url in urls:
     formatted = click.format_filename(url)
     click.echo('Processing "%s"...' % (formatted, ))
+    fsurl = fs.abspath(url)
+    if os.path.exists(fs.from_posix(fsurl)):
+      url = fsurl
 
     # Create parser to use
     if resolve:

--- a/prance/util/url.py
+++ b/prance/util/url.py
@@ -64,6 +64,7 @@ def absurl(url, relative_to = None):
   # That is, we'll have to set the fragment of the reference URL to that
   # of the input URL, and return the result.
   import os.path
+  from .fs import from_posix, to_posix, abspath
   result_list = None
   if not parsed.path:
     if not reference or not reference.path:
@@ -71,7 +72,7 @@ def absurl(url, relative_to = None):
           ' without a reference with path!')
     result_list = list(reference)
     result_list[5] = parsed.fragment
-  elif os.path.isabs(parsed.path):
+  elif os.path.isabs(from_posix(parsed.path)):
     # We have an absolute path, so we can ignore the reference entirely!
     result_list = list(parsed)
     result_list[0] = 'file'  # in case it was empty
@@ -86,8 +87,7 @@ def absurl(url, relative_to = None):
 
     result_list = list(parsed)
     result_list[0] = 'file'  # in case it was empty
-    from .fs import abspath
-    result_list[2] = abspath(parsed.path, reference.path)
+    result_list[2] = abspath(from_posix(parsed.path), from_posix(reference.path))
 
   # Reassemble the result and return it
   result = parse.ParseResult(*result_list)
@@ -110,8 +110,8 @@ def fetch_url(url):
   content = None
   content_type = None
   if url.scheme in (None, '', 'file'):
-    from .fs import read_file
-    content = read_file(url.path)
+    from .fs import read_file, from_posix
+    content = read_file(from_posix(url.path))
   else:
     import requests
     response = requests.get(url.geturl())

--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,11 @@ if __name__ == '__main__':
         'dev': dev_require,
         'icu': icu_require,
       },
-      scripts = [
-        'scripts/prance',
-      ],
+      entry_points={
+          'console_scripts': [
+              'prance=prance.cli:cli',
+           ],
+      },
       zip_safe = True,
       test_suite = 'tests',
       setup_requires = ['pytest-runner'],

--- a/tests/test_util_fs.py
+++ b/tests/test_util_fs.py
@@ -8,6 +8,7 @@ __all__ = ()
 
 
 import os
+import sys
 
 import pytest
 
@@ -16,23 +17,48 @@ from prance.util import fs
 
 def test_canonical():
   testname = 'tests/symlink_test'
-  res = fs.canonical_filename(testname)
-  expected = os.path.join(os.getcwd(), 'tests/with_externals.yaml')
-  assert res == expected
+  if sys.platform != "win32":
+    res = fs.canonical_filename(testname)
+    expected = os.path.join(os.getcwd(), 'tests/with_externals.yaml')
+    assert res == expected
 
+def test_to_posix_rel():
+  test = "tests/with_externals.yaml"
+  assert fs.to_posix(os.path.normpath(test)) == test
+
+def test_to_posix_abs():
+  if sys.platform == "win32":
+    test = "c:\\windows\\notepad.exe"
+    expected = "/c:/windows/notepad.exe"
+  else:
+    test = "/etc/passwd"
+    expected = test
+  assert fs.to_posix(test) == expected
+
+def test_from_posix_rel():
+  test = "tests/with_externals.yaml"
+  assert fs.from_posix(test) == os.path.normpath(test)
+
+def test_from_posix_abs():
+  if sys.platform == "win32":
+    test = "/c:/windows/notepad.exe"
+    expected = "c:\\windows\\notepad.exe"
+  else:
+    test = "/etc/passwd"
+    expected = test
+  assert fs.from_posix(test) == expected
 
 def test_abspath_basics():
-  testname = 'tests/with_externals.yaml'
+  testname = os.path.normpath('tests/with_externals.yaml')
   res = fs.abspath(testname)
-  expected = os.path.join(os.getcwd(), testname)
+  expected = fs.to_posix(os.path.join(os.getcwd(), testname))
   assert res == expected
-
 
 def test_abspath_relative():
   testname = 'error.json'
   relative = os.path.join(os.getcwd(), 'tests/with_externals.yaml')
   res = fs.abspath(testname, relative)
-  expected = os.path.join(os.getcwd(), 'tests', testname)
+  expected = fs.to_posix(os.path.join(os.getcwd(), 'tests', testname))
   assert res == expected
 
 
@@ -40,7 +66,7 @@ def test_abspath_relative_dir():
   testname = 'error.json'
   relative = os.path.join(os.getcwd(), 'tests')
   res = fs.abspath(testname, relative)
-  expected = os.path.join(os.getcwd(), 'tests', testname)
+  expected = fs.to_posix(os.path.join(os.getcwd(), 'tests', testname))
   assert res == expected
 
 

--- a/tests/test_util_resolver.py
+++ b/tests/test_util_resolver.py
@@ -9,12 +9,12 @@ __all__ = ()
 
 import pytest
 
+from prance.util import fs
 from prance.util import resolver
 from prance.util.url import ResolutionError
 
 
 def get_specs(fname):
-  from prance.util import fs
   specs = fs.read_file(fname)
 
   from prance.util import formats
@@ -47,15 +47,16 @@ def test_resolver_noname(externals_file):
 
 def test_resolver_named(externals_file):
   import os.path
+  from prance.util import fs
   res = resolver.RefResolver(externals_file,
-      os.path.abspath('tests/with_externals.yaml'))
+      fs.abspath('tests/with_externals.yaml'))
   res.resolve_references()
 
 
 def test_resolver_missing_reference(missing_file):
   import os.path
   res = resolver.RefResolver(missing_file,
-      os.path.abspath('tests/missing_reference.yaml'))
+      fs.abspath('tests/missing_reference.yaml'))
   with pytest.raises(ResolutionError) as exc:
     res.resolve_references()
 
@@ -65,7 +66,7 @@ def test_resolver_missing_reference(missing_file):
 def test_resolver_recursive(recursive_file):
   import os.path
   res = resolver.RefResolver(recursive_file,
-      os.path.abspath('tests/recursive.yaml'))
+      fs.abspath('tests/recursive.yaml'))
   with pytest.raises(ResolutionError) as exc:
     res.resolve_references()
 

--- a/tests/test_util_url.py
+++ b/tests/test_util_url.py
@@ -6,6 +6,8 @@ __copyright__ = 'Copyright (c) 2016-2017 Jens Finkhaeuser'
 __license__ = 'MIT +no-false-attribs'
 __all__ = ()
 
+import sys
+
 import pytest
 
 from prance.util import url
@@ -28,14 +30,23 @@ def test_absurl_http_fragment():
 
 
 def test_absurl_file():
-  base = 'file:///etc/passwd'
-  test = 'group'
+  if sys.platform == "win32":
+    base = 'file:///c:/windows/notepad.exe'
+    test = "regedit.exe"
+    expect = 'file:///c:/windows/regedit.exe'
+  else:
+    base = 'file:///etc/passwd'
+    test = 'group'
+    expect = 'file:///etc/group'
   res = url.absurl(test, base)
-  assert res.geturl() == 'file:///etc/group'
+  assert res.geturl() == expect
 
 
 def test_absurl_absfile():
-  test = 'file:///etc/passwd'
+  if sys.platform == "win32":
+    test = 'file:///c:/windows/notepad.exe'
+  else:
+    test = 'file:///etc/passwd'
   res = url.absurl(test)
   assert res.geturl() == test
 


### PR DESCRIPTION
This is not the nicest way to do it, but it is the less intrusive.  The difficulty is mostly the poor quality of urllib.parse (even acknowledge by the maintainers) and the manipulation of paths as string.  Switching to something like pathlib (including pathlib2 package for py2) and uritools could help (and remove a lot of the actual code).

I follow mostly [this convention](https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/) for Windows file.  I think they are better than encoding the '\\' as %3C and other trick like that.  The code is probably however poor to handle space properly (didn't try).