### PR TITLE
Python pkg url refs

### DIFF
--- a/prance/util/url.py
+++ b/prance/util/url.py
@@ -139,9 +139,15 @@ def fetch_py_pkg_url(url):
   from .fs import read_file, from_posix
   import pkg_resources
   pkg = url.netloc
-  # TODO(dmr, 2018-02-17): I think this parses as `/base.yaml`;
-  # confirm this works in general
   res = url.path
+
+  # url.path yields e.g. '/base.yaml', whereas the use of
+  # resource_filename ensures that 'base.yaml' works no matter where
+  # it's nested, so strip off the leading slash just in case this
+  # could cause issues in some possible case.
+  if res[0] == '/':
+    res = res[1:]
+
   path = pkg_resources.resource_filename(pkg, res)
   content = read_file(from_posix(path))
   return content

--- a/prance/util/url.py
+++ b/prance/util/url.py
@@ -113,6 +113,8 @@ def fetch_url(url):
   if url.scheme in (None, '', 'file'):
     from .fs import read_file, from_posix
     content = read_file(from_posix(url.path))
+  elif url.scheme == 'python':
+    content = fetch_py_pkg_url(url)
   else:
     import requests
     response = requests.get(url.geturl())
@@ -122,3 +124,24 @@ def fetch_url(url):
   # Now return the parsed results
   from .formats import parse_spec
   return parse_spec(content, url.path, content_type = content_type)
+
+
+def fetch_py_pkg_url(url):
+  """
+  fetch a url which references an importable python package
+
+  the url looks like
+
+  ```
+  python://common_swag/base.yaml#/definitions/Severity
+  ```
+  """
+  from .fs import read_file, from_posix
+  import pkg_resources
+  pkg = url.netloc
+  # TODO(dmr, 2018-02-17): I think this parses as `/base.yaml`;
+  # confirm this works in general
+  res = url.path
+  path = pkg_resources.resource_filename(pkg, res)
+  content = read_file(from_posix(path))
+  return content

--- a/prance/util/url.py
+++ b/prance/util/url.py
@@ -128,7 +128,7 @@ def fetch_url(url):
 
 def fetch_py_pkg_url(url):
   """
-  fetch a url which references an importable python package
+  Fetch a url which references an importable python package.
 
   the url looks like
 


### PR DESCRIPTION
Unlike the speedup stuff, this is a little weird, so I do anticipate some discussion.

Often, we have some common swagger defs that we want to include in several separate services. We'd like to write these once, so we don't have to change them 10 times in 10 separate services. But we want each service to have its own swagger in its own repo.

The solution is to put the common swagger in a separate python package, and use the data file resource api to resolve paths to it outside. This requires a different uri scheme. I decided to just use `python://` to refer to a python package (which can be imported).

Many swagger validation libraries have a resolver with an editable `schemes` dict, mapping schemes to methods. Had such existed, I would have just added the new fetch method to this dict, but it didn't so I just added an if-branch.