### PR TITLE
document extension, bump version for new release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,56 @@ Note that the `flex` validator simply accepts integer status codes, despite them
 See `issue #5 <https://github.com/jfinkhaeuser/prance/issues/5>`__ for details. Therefore, `flex` also
 does not support the `strict` option.
 
+Extensions
+----------
+
+Prance includes the ability to reference outside swagger definitions
+in outside Python packages. Such a package must already be importable
+(i.e. installed), and be accessible via the
+[ResourceManager API](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#resourcemanager-api)
+(some more info [here](https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files)).
+
+For example, you might create a package `common_swag` with the file
+`base.yaml` containing the definition
+
+.. code:: yaml
+    definitions:
+      Severity:
+        type: string
+        enum:
+        - INFO
+        - WARN
+        - ERROR
+        - FATAL
+
+In the `setup.py` for `common_swag` you would add lines such as
+
+.. code:: python
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    package_data={
+        '': '*.yaml'
+    }
+
+Then, having installed `common_swag` into some application, you could
+now write
+
+.. code:: yaml
+    definitions:
+      Message:
+        type: object
+        properties:
+          severity:
+            $ref: 'python://common_swag/base.yaml#/definitions/Severity'
+          code:
+            type: string
+          summary:
+            type: string
+          description:
+            type: string
+        required:
+        - severity
+        - summary
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,7 @@ For example, you might create a package `common_swag` with the file
 `base.yaml` containing the definition
 
 .. code:: yaml
+
     definitions:
       Severity:
         type: string
@@ -119,6 +120,7 @@ For example, you might create a package `common_swag` with the file
 In the `setup.py` for `common_swag` you would add lines such as
 
 .. code:: python
+
     packages=find_packages('src'),
     package_dir={'': 'src'},
     package_data={
@@ -129,6 +131,7 @@ Then, having installed `common_swag` into some application, you could
 now write
 
 .. code:: yaml
+
     definitions:
       Message:
         type: object

--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,8 @@ Extensions
 Prance includes the ability to reference outside swagger definitions
 in outside Python packages. Such a package must already be importable
 (i.e. installed), and be accessible via the
-[ResourceManager API](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#resourcemanager-api)
-(some more info [here](https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files)).
+`ResourceManager API <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#resourcemanager-api>`__
+(some more info `here <https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files>`__).
 
 For example, you might create a package `common_swag` with the file
 `base.yaml` containing the definition

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,7 @@ author = 'Jens Finkhaeuser'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = '0.8.0'
+release = '0.9.0'
 
 # The short X.Y version.
 import re

--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -12,7 +12,7 @@ __author__ = 'Jens Finkhaeuser'
 __copyright__ = 'Copyright (c) 2016-2017 Jens Finkhaeuser'
 __license__ = 'MIT +no-false-attribs'
 __all__ = ('util', 'mixins', 'cli')
-__version__ = '0.8.0'
+__version__ = '0.9.0'
 
 
 # Define our own error class

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.9.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
   # Run setup
   setup(
       name = 'prance',
-      version = '0.8.0',
+      version = '0.9.0',
       description = 'Swagger/OpenAPI 2.0 Parser',
       long_description = open('README.rst').read(),
       # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
on the theory that you might consider a release, I did this.

I bumped to 0.9 on the theory that you were using semver; the addition of `python://` represents a backwards-compatible change to the api.

arguably, this calls for documenting this feature, but maybe you're willing to stretch a point.