### PR TITLE
Prevent warning on Python 3 about importing from collections

### DIFF
--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -134,7 +134,10 @@ class BaseParser(mixins.YAMLMixin, mixins.JSONMixin, object):
 
   def _validate(self):
     # Ensure specification is a mapping
-    from collections import Mapping
+    try:
+      from collections.abc import Mapping
+    except ImportError:  # Python 2
+      from collections import Mapping
     if not isinstance(self.specification, Mapping):
       raise ValidationError('Could not parse specifications!')
 

--- a/prance/util/__init__.py
+++ b/prance/util/__init__.py
@@ -16,15 +16,18 @@ def stringify_keys(data):
   :return: A new dict-like object of the same type with stringified keys,
       but the same values.
   """
-  import collections
-  assert isinstance(data, collections.Mapping)
+  try:
+    from collections.abc import Mapping
+  except ImportError:  # Python 2
+    from collections import Mapping
+  assert isinstance(data, Mapping)
 
   ret = type(data)()
   import six
   for key, value in six.iteritems(data):
     if not isinstance(key, six.string_types):
       key = str(key)
-    if isinstance(value, collections.Mapping):
+    if isinstance(value, Mapping):
       value = stringify_keys(value)
     ret[key] = value
   return ret


### PR DESCRIPTION
Addresses the following warning:

"DeprecationWarning: Using or importing the ABCs from
'collections' instead of from 'collections.abc' is
deprecated, and in 3.8 it will stop working"



@jfinkhaeuser
