### PR TITLE
Allow refs to sequence elements

### DIFF
--- a/prance/util/path.py
+++ b/prance/util/path.py
@@ -38,10 +38,12 @@ def path_get(obj, path, defaultvalue = None):
     if path is None or len(path) < 1:
       return obj or defaultvalue
 
-    if not isinstance(path[0], int):
+    try:
+      idx = int(path[0])
+    except ValueError:
       raise KeyError('Sequences need integer indices only.')
 
-    return path_get(obj[path[0]], path[1:], defaultvalue)
+    return path_get(obj[idx], path[1:], defaultvalue)
 
   else:
     # Path must be empty.
@@ -139,26 +141,30 @@ def path_set(obj, path, value, **options):
     return obj
 
   elif isinstance(obj, collections.Sequence):
+    idx = path[0]
+
     # If we don't have a mutable sequence, we should raise a TypeError
     if not isinstance(obj, collections.MutableSequence):
       raise TypeError('Sequence is not mutable: %s' % (type(obj),))
 
     # Ensure integer indices
-    if not isinstance(path[0], int):
+    try:
+      idx = int(idx)
+    except ValueError:
       raise KeyError('Sequences need integer indices only.')
 
     # If we're supposed to create and the index at path[0] doesn't exist,
     # then we need to push some dummy objects.
     if create:
-      fill_sequence(obj, path[0], safe_idx(path, 1))
+      fill_sequence(obj, idx, safe_idx(path, 1))
 
     # If the path has only one element, we just overwrite the element at the
     # given index. Otherwise we recurse.
     # print('pl', len(path))
     if len(path) == 1:
-      obj[path[0]] = value
+      obj[idx] = value
     else:
-      path_set(obj[path[0]], path[1:], value, create = create)
+      path_set(obj[idx], path[1:], value, create = create)
 
     return obj
   else:


### PR DESCRIPTION
When attempting to $ref an element in a sequence in a YAML (and probably JSON)
file, it raised the exception 'Sequences need integer indices only.' despite
the index being a number, because the datatype was a string.

This is the full exception received (paths edited):

```
>>> parser = prance.ResolvingParser('sequence_index_test.yaml', strict=False)
Traceback (most recent call last):
  File "~/.local/lib/python3.6/site-packages/prance/util/resolver.py", line 135, in _dereference
    value = path_get(value, obj_path)
  File "~/.local/lib/python3.6/site-packages/prance/util/path.py", line 35, in path_get
    return path_get(obj[path[0]], path[1:], defaultvalue)
  File "~/.local/lib/python3.6/site-packages/prance/util/path.py", line 35, in path_get
    return path_get(obj[path[0]], path[1:], defaultvalue)
  File "~/.local/lib/python3.6/site-packages/prance/util/path.py", line 35, in path_get
    return path_get(obj[path[0]], path[1:], defaultvalue)
  [Previous line repeated 1 more time]
  File "~/.local/lib/python3.6/site-packages/prance/util/path.py", line 42, in path_get
    raise KeyError('Sequences need integer indices only.')
KeyError: 'Sequences need integer indices only.'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/.local/lib/python3.6/site-packages/prance/__init__.py", line 260, in __init__
    **kwargs
  File "~/.local/lib/python3.6/site-packages/prance/__init__.py", line 104, in __init__
    self.parse()
  File "~/.local/lib/python3.6/site-packages/prance/__init__.py", line 134, in parse
    self._validate()
  File "~/.local/lib/python3.6/site-packages/prance/__init__.py", line 271, in _validate
    resolver.resolve_references()
  File "~/.local/lib/python3.6/site-packages/prance/util/resolver.py", line 72, in resolve_references
    self.specs = self._resolve_partial(self.parsed_url, self.specs, ())
  File "~/.local/lib/python3.6/site-packages/prance/util/resolver.py", line 163, in _resolve_partial
    recursions)))
  File "~/.local/lib/python3.6/site-packages/prance/util/resolver.py", line 105, in _dereferencing_iterator
    ref_value = self._dereference(ref_url, obj_path, next_recursions)
  File "~/.local/lib/python3.6/site-packages/prance/util/resolver.py", line 138, in _dereference
    % (ref_url.geturl(), ))
prance.util.url.ResolutionError: Cannot resolve reference "file://.../sequence_index_test.yaml#/components/examples/PartlyReused/value/0"!
```

This changes the method of checking if the index is a number or not to
allow these refs to work.

I'm happy to add a test case for this, but I'm not sure how to format it offhand. However, I wrote an example file to test this:

```yaml
openapi: 3.0.0
info:
  title: Minimal test for refs in sequences
  version: 0.0.1
servers:
  - url: https://localhost/
paths:
  /test:
    get:
      summary: Test endpoint
      responses:
        200:
          description: Test indexing into a sequence
          content:
            application/json:
              schema:
                type: string
              example:
                $ref: '#/components/examples/PartlyReused/value/0'
  /useCase:
    get:
      summary: Why this is useful
      responses:
        200:
          description: Example which uses everything in the list
          content:
            application/json:
              schema:
                type: array
                items:
                  type: string
              examples:
                response:
                  $ref: '#/components/examples/PartlyReused'
components:
  examples:
    PartlyReused:
      value:
        - 'some really long or specific string'
        - 'some other comparably long or specific string'
```

Changes proposed in this PR:
- `isinstance(path[0], int)` -> `try: int(path[0])`

@jfinkhaeuser
