### PR TITLE
Normalize ~1 to / and ~0 to ~ when splitting the path/fragment from an URL reference

### DIFF
--- a/prance/util/url.py
+++ b/prance/util/url.py
@@ -124,6 +124,13 @@ def split_url_reference(base_url, reference):
   while len(obj_path) and not obj_path[0]:
     obj_path = obj_path[1:]
 
+  # Normalize the object path by substituting ~1 and ~0 respectively.
+  def _normalize(path):
+    path = path.replace('~1', '/')
+    path = path.replace('~0', '~')
+    return path
+  obj_path = [_normalize(p) for p in obj_path]
+
   return parsed_url, obj_path
 
 

--- a/tests/specs/issue_38_a.yaml
+++ b/tests/specs/issue_38_a.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.0
+info:
+  title: Minimal test for refs in sequences
+  version: 0.0.1
+servers:
+  - url: https://localhost/
+paths:
+  /api/v2/vms:
+    $ref: ./issue_38_b.yaml#/paths/~1api~1v2~1vms

--- a/tests/specs/issue_38_b.yaml
+++ b/tests/specs/issue_38_b.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  title: Minimal test for refs in sequences
+  version: 0.0.1
+servers:
+  - url: https://localhost/
+paths:
+  /api/v2/vms:
+    get:
+      operationId: list_vm
+      description: get all

--- a/tests/test_util_resolver.py
+++ b/tests/test_util_resolver.py
@@ -247,3 +247,15 @@ def test_issue_22_empty_path(externals_file):
   # Previously defined keys must not
   assert 'overwritten' not in param
   assert '$ref' not in param
+
+def test_issue_38_tilde_one():
+  specs = get_specs('tests/specs/issue_38_a.yaml')
+  print(specs)
+  res = resolver.RefResolver(specs,
+      fs.abspath('tests/specs/issue_38_a.yaml'))
+  res.resolve_references()
+
+  path = res.specs['paths']['/api/v2/vms']
+  assert 'get' in path
+  assert 'operationId' in path['get']
+  assert 'description' in path['get']

--- a/tests/test_util_url.py
+++ b/tests/test_util_url.py
@@ -117,6 +117,13 @@ def test_split_url_reference():
   assert path[0] == 'foo'
   assert path[1] == 'bar'
 
+  # Reference with escaped parts
+  parsed, path = url.split_url_reference(base, 'http://somewhere/#foo/bar~1baz~1quux~0foo')
+  assert parsed.netloc == 'somewhere'
+  assert len(path) == 2
+  assert path[0] == 'foo'
+  assert path[1] == 'bar/baz/quux~foo'
+
 
 def test_fetch_url_file():
   from prance.util import fs


### PR DESCRIPTION
Fixes #38 .

Changes proposed in this PR:
- Implement special tilde treatment from JSON pointers spec.
