### PR TITLE
Reduce reliance on network in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ matrix:
   # Main development version
   - python: '3.6'
     env:
-      global:
-        - REQUIREMENTS=requirements_no_icu.txt
-        - TEST_ARGS="--addopts \"-m 'not requires_network'\""
+      - REQUIREMENTS=requirements_no_icu.txt
+      - TEST_ARGS="--addopts \"-m 'not requires_network'\""
       #  - python: '3.6'
       #    env:
       #      REQUIREMENTS: requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ jobs:
   #       travis supports them.
   #   - python: 'pypy3-7.1.1'  # Try versioning; it sucks, but what are you to do?
   #     env: REQUIREMENTS=requirements_no_icu.txt
-  - python: '3.5'
-    env: REQUIREMENTS=requirements_no_icu.txt
-    script: python setup.py test --addopts '-m "not requires_network"'
+  # XXX Fails with an intenral error
+  #  - python: '3.5'
+  #    env: REQUIREMENTS=requirements_no_icu.txt
+  #    script: python setup.py test --addopts '-m "not requires_network"'
   - python: '3.7'
     env: REQUIREMENTS=requirements_no_icu.txt
     script: python setup.py test --addopts '-m "not requires_network"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,38 +6,30 @@ jobs:
   - python: '3.6'
     env: REQUIREMENTS=requirements_no_icu.txt
     script: python setup.py test --addopts '-m "not requires_network"'
-      #  - python: '3.6'
-      #    env:
-      #      REQUIREMENTS: requirements.txt
-      #      EXTRA_STEPS: flake8 build_sphinx
-      #      DEPLOY: 1
-      #  - python: '3.6'
-      #    env:
-      #      REQUIREMENTS: requirements_flex.txt
-      #      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
-      #
-      #  # Other supported versions
-      #  # FIXME we're disabling pypy builds until
-      #  #       travis supports them.
-      #  #   - python: 'pypy3-7.1.1'  # Try versioning; it sucks, but what are you to do?
-      #  #     env: REQUIREMENTS=requirements_no_icu.txt
-      #  - python: '3.5'
-      #    env:
-      #      REQUIREMENTS: requirements_no_icu.txt
-      #      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
-      #  - python: '3.7'
-      #    env:
-      #      REQUIREMENTS: requirements_no_icu.txt
-      #      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
-      #  - python: '3.8'
-      #    env:
-      #      REQUIREMENTS: requirements_no_icu.txt
-      #      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
+  - python: '3.6'
+    env: REQUIREMENTS=requirements.txt DEPLOY=1
+    script: python setup.py test flake8 build_sphinx
+  - python: '3.6'
+    env: REQUIREMENTS=requirements_flex.txt
+    script: python setup.py test --addopts '-m "not requires_network"'
+
+  # Other supported versions
+  # FIXME we're disabling pypy builds until
+  #       travis supports them.
+  #   - python: 'pypy3-7.1.1'  # Try versioning; it sucks, but what are you to do?
+  #     env: REQUIREMENTS=requirements_no_icu.txt
+  - python: '3.5'
+    env: REQUIREMENTS=requirements_no_icu.txt
+    script: python setup.py test --addopts '-m "not requires_network"'
+  - python: '3.7'
+    env: REQUIREMENTS=requirements_no_icu.txt
+    script: python setup.py test --addopts '-m "not requires_network"'
+  - python: '3.8'
+    env: REQUIREMENTS=requirements_no_icu.txt
+    script: python setup.py test --addopts '-m "not requires_network"'
 
 install:
   - pip install -r ${REQUIREMENTS}
-    #script:
-    #  - python setup.py test ${EXTRA_STEPS} ${TEST_ARGS}
 after_success:
   - test "${TRAVIS_TAG}" != "" && docs/deploy.sh
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ matrix:
   include:
   # Main development version
   - python: '3.6'
-    env: REQUIREMENTS=requirements_no_icu.txt TEST_ARGS="-m 'not requires_network'"
+    env:
+      REQUIREMENTS: requirements_no_icu.txt
+      TEST_ARGS: --addopts "-m 'not requires_network'"
   - python: '3.6'
-    env: REQUIREMENTS=requirements.txt EXTRA_STEPS="flake8 build_sphinx" DEPLOY=1 TEST_ARGS=""
+    env:
+      REQUIREMENTS: requirements.txt
+      EXTRA_STEPS: flake8 build_sphinx
+      DEPLOY: 1
   - python: '3.6'
-    env: REQUIREMENTS=requirements_flex.txt TEST_ARGS="-m 'not requires_network'"
+    env:
+      REQUIREMENTS: requirements_flex.txt
+      TEST_ARGS: --addopts "-m 'not requires_network'"
 
   # Other supported versions
   # FIXME we're disabling pypy builds until
@@ -16,16 +23,22 @@ matrix:
   #   - python: 'pypy3-7.1.1'  # Try versioning; it sucks, but what are you to do?
   #     env: REQUIREMENTS=requirements_no_icu.txt
   - python: '3.5'
-    env: REQUIREMENTS=requirements_no_icu.txt TEST_ARGS="-m 'not requires_network'"
+    env:
+      REQUIREMENTS: requirements_no_icu.txt
+      TEST_ARGS: --addopts "-m 'not requires_network'"
   - python: '3.7'
-    env: REQUIREMENTS=requirements_no_icu.txt TEST_ARGS="-m 'not requires_network'"
+    env:
+      REQUIREMENTS: requirements_no_icu.txt
+      TEST_ARGS: --addopts "-m 'not requires_network'"
   - python: '3.8'
-    env: REQUIREMENTS=requirements_no_icu.txt TEST_ARGS="-m 'not requires_network'"
+    env:
+      REQUIREMENTS: requirements_no_icu.txt
+      TEST_ARGS: --addopts "-m 'not requires_network'"
 
 install:
   - pip install -r ${REQUIREMENTS}
 script:
-  - python setup.py test ${EXTRA_STEPS} --addopts "${TEST_ARGS}"
+  - python setup.py test ${EXTRA_STEPS} ${TEST_ARGS}
 after_success:
   - test "${TRAVIS_TAG}" != "" && docs/deploy.sh
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ jobs:
   #       travis supports them.
   #   - python: 'pypy3-7.1.1'  # Try versioning; it sucks, but what are you to do?
   #     env: REQUIREMENTS=requirements_no_icu.txt
-  # XXX Fails with an intenral error
-  #  - python: '3.5'
-  #    env: REQUIREMENTS=requirements_no_icu.txt
-  #    script: python setup.py test --addopts '-m "not requires_network"'
+
+  - python: '3.5'
+    env: REQUIREMENTS=requirements_no_icu.txt
+    script: python setup.py test --addopts '-m "not requires_network"'
   - python: '3.7'
     env: REQUIREMENTS=requirements_no_icu.txt
     script: python setup.py test --addopts '-m "not requires_network"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
 dist: bionic
-matrix:
+jobs:
   include:
   # Main development version
   - python: '3.6'
-    env:
-      - REQUIREMENTS=requirements_no_icu.txt
-      - TEST_ARGS="--addopts '-m not\\ requires_network'"
+    env: REQUIREMENTS=requirements_no_icu.txt
+    script: python setup.py test --addopts '-m "not requires_network"'
       #  - python: '3.6'
       #    env:
       #      REQUIREMENTS: requirements.txt
@@ -37,8 +36,8 @@ matrix:
 
 install:
   - pip install -r ${REQUIREMENTS}
-script:
-  - python setup.py test ${EXTRA_STEPS} ${TEST_ARGS}
+    #script:
+    #  - python setup.py test ${EXTRA_STEPS} ${TEST_ARGS}
 after_success:
   - test "${TRAVIS_TAG}" != "" && docs/deploy.sh
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ matrix:
   # Main development version
   - python: '3.6'
     env:
-      REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: --addopts\ "-m 'not requires_network'"
+      global:
+        - REQUIREMENTS=requirements_no_icu.txt
+        - TEST_ARGS="--addopts \"-m 'not requires_network'\""
       #  - python: '3.6'
       #    env:
       #      REQUIREMENTS: requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - python: '3.6'
     env:
       - REQUIREMENTS=requirements_no_icu.txt
-      - TEST_ARGS="--addopts '-m "not requires_network"'"
+      - TEST_ARGS="--addopts '-m \"not requires_network\"'"
       #  - python: '3.6'
       #    env:
       #      REQUIREMENTS: requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - python: '3.6'
     env:
       - REQUIREMENTS=requirements_no_icu.txt
-      - TEST_ARGS="--addopts \"-m 'not requires_network'\""
+      - TEST_ARGS="--addopts '-m "not requires_network"'"
       #  - python: '3.6'
       #    env:
       #      REQUIREMENTS: requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,34 +6,34 @@ matrix:
   - python: '3.6'
     env:
       REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
-  - python: '3.6'
-    env:
-      REQUIREMENTS: requirements.txt
-      EXTRA_STEPS: flake8 build_sphinx
-      DEPLOY: 1
-  - python: '3.6'
-    env:
-      REQUIREMENTS: requirements_flex.txt
-      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
-
-  # Other supported versions
-  # FIXME we're disabling pypy builds until
-  #       travis supports them.
-  #   - python: 'pypy3-7.1.1'  # Try versioning; it sucks, but what are you to do?
-  #     env: REQUIREMENTS=requirements_no_icu.txt
-  - python: '3.5'
-    env:
-      REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
-  - python: '3.7'
-    env:
-      REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
-  - python: '3.8'
-    env:
-      REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
+      TEST_ARGS: --addopts\ "-m 'not requires_network'"
+      #  - python: '3.6'
+      #    env:
+      #      REQUIREMENTS: requirements.txt
+      #      EXTRA_STEPS: flake8 build_sphinx
+      #      DEPLOY: 1
+      #  - python: '3.6'
+      #    env:
+      #      REQUIREMENTS: requirements_flex.txt
+      #      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
+      #
+      #  # Other supported versions
+      #  # FIXME we're disabling pypy builds until
+      #  #       travis supports them.
+      #  #   - python: 'pypy3-7.1.1'  # Try versioning; it sucks, but what are you to do?
+      #  #     env: REQUIREMENTS=requirements_no_icu.txt
+      #  - python: '3.5'
+      #    env:
+      #      REQUIREMENTS: requirements_no_icu.txt
+      #      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
+      #  - python: '3.7'
+      #    env:
+      #      REQUIREMENTS: requirements_no_icu.txt
+      #      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
+      #  - python: '3.8'
+      #    env:
+      #      REQUIREMENTS: requirements_no_icu.txt
+      #      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
 
 install:
   - pip install -r ${REQUIREMENTS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ matrix:
   include:
   # Main development version
   - python: '3.6'
-    env: REQUIREMENTS=requirements_no_icu.txt
+    env: REQUIREMENTS=requirements_no_icu.txt TEST_ARGS="-m 'not requires_network'"
   - python: '3.6'
-    env: REQUIREMENTS=requirements.txt EXTRA_STEPS="flake8 build_sphinx" DEPLOY=1
+    env: REQUIREMENTS=requirements.txt EXTRA_STEPS="flake8 build_sphinx" DEPLOY=1 TEST_ARGS=""
   - python: '3.6'
-    env: REQUIREMENTS=requirements_flex.txt
+    env: REQUIREMENTS=requirements_flex.txt TEST_ARGS="-m 'not requires_network'"
 
   # Other supported versions
   # FIXME we're disabling pypy builds until
@@ -16,16 +16,16 @@ matrix:
   #   - python: 'pypy3-7.1.1'  # Try versioning; it sucks, but what are you to do?
   #     env: REQUIREMENTS=requirements_no_icu.txt
   - python: '3.5'
-    env: REQUIREMENTS=requirements_no_icu.txt
+    env: REQUIREMENTS=requirements_no_icu.txt TEST_ARGS="-m 'not requires_network'"
   - python: '3.7'
-    env: REQUIREMENTS=requirements_no_icu.txt
+    env: REQUIREMENTS=requirements_no_icu.txt TEST_ARGS="-m 'not requires_network'"
   - python: '3.8'
-    env: REQUIREMENTS=requirements_no_icu.txt
+    env: REQUIREMENTS=requirements_no_icu.txt TEST_ARGS="-m 'not requires_network'"
 
 install:
   - pip install -r ${REQUIREMENTS}
 script:
-  - python setup.py test ${EXTRA_STEPS}
+  - python setup.py test ${EXTRA_STEPS} --addopts "${TEST_ARGS}"
 after_success:
   - test "${TRAVIS_TAG}" != "" && docs/deploy.sh
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - python: '3.6'
     env:
       REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: --addopts "-m 'not requires_network'"
+      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
   - python: '3.6'
     env:
       REQUIREMENTS: requirements.txt
@@ -15,7 +15,7 @@ matrix:
   - python: '3.6'
     env:
       REQUIREMENTS: requirements_flex.txt
-      TEST_ARGS: --addopts "-m 'not requires_network'"
+      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
 
   # Other supported versions
   # FIXME we're disabling pypy builds until
@@ -25,15 +25,15 @@ matrix:
   - python: '3.5'
     env:
       REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: --addopts "-m 'not requires_network'"
+      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
   - python: '3.7'
     env:
       REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: --addopts "-m 'not requires_network'"
+      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
   - python: '3.8'
     env:
       REQUIREMENTS: requirements_no_icu.txt
-      TEST_ARGS: --addopts "-m 'not requires_network'"
+      TEST_ARGS: "--addopts \"-m 'not requires_network'\""
 
 install:
   - pip install -r ${REQUIREMENTS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - python: '3.6'
     env:
       - REQUIREMENTS=requirements_no_icu.txt
-      - TEST_ARGS="--addopts '-m \"not requires_network\"'"
+      - TEST_ARGS="--addopts '-m not\ requires_network'"
       #  - python: '3.6'
       #    env:
       #      REQUIREMENTS: requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - python: '3.6'
     env:
       - REQUIREMENTS=requirements_no_icu.txt
-      - TEST_ARGS="--addopts '-m not\ requires_network'"
+      - TEST_ARGS="--addopts '-m not\\ requires_network'"
       #  - python: '3.6'
       #    env:
       #      REQUIREMENTS: requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,13 @@ To run all tests without these spec validation tests, use:
 $ pytest -k 'not test_zzz_specs.py'
 ```
 
+To run all tests requiring/not requiring a network connection, use:
+
+```bash
+$ pytest -m 'requires_network'
+$ pytest -m 'not requires_network'
+```
+
 Run tests on multiple Python versions:
 
 ```bash

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,4 +88,4 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "python setup.py test --addopts '-m not\ requires_network'"
+  - "python setup.py test --addopts '-m not\\ requires_network\"'"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,13 +9,14 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
+    # XXX 3.5 fails with an internal error
+    #    - PYTHON: "C:\\Python35"
+    #      PYTHON_VERSION: "3.5.x"
+    #      PYTHON_ARCH: "32"
+    #
+    #    - PYTHON: "C:\\Python35-x64"
+    #      PYTHON_VERSION: "3.5.x"
+    #      PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
@@ -87,4 +88,4 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "python setup.py test"
+  - "python setup.py test --addopts '-m \"not requires_network\"'"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,4 +88,4 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "python setup.py test --addopts '-m not\\ requires_network\"'"
+  - python setup.py test --addopts '-m "not requires_network"'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,4 +88,4 @@ build_script:
 
 test_script:
   # Run the project tests
-  - python setup.py test --addopts '-m "not requires_network"'
+  - python setup.py test --addopts "-m 'not requires_network'"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,14 +9,13 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    # XXX 3.5 fails with an internal error
-    #    - PYTHON: "C:\\Python35"
-    #      PYTHON_VERSION: "3.5.x"
-    #      PYTHON_ARCH: "32"
-    #
-    #    - PYTHON: "C:\\Python35-x64"
-    #      PYTHON_VERSION: "3.5.x"
-    #      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,4 +88,4 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "python setup.py test --addopts '-m \"not requires_network\"'"
+  - "python setup.py test --addopts '-m not\ requires_network'"

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ test = pytest
 [tool:pytest]
 addopts = --verbose --cov=prance --cov-report=term-missing --cov-fail-under=95
 testpaths = tests
+markers =
+  requires_network: Marks test as requring network connections (deselect with '-m "not requires_network"')
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
   dev_require = [
     'tox>=3.14',
     'bumpversion>=0.5',
-    'pytest>=5.3',
+    'pytest>=5.3,>=5.3.4',
     'pytest-cov>=2.8',
     'flake8>=3.7',
     'pep8-naming>=0.9',

--- a/tests/mock_response.py
+++ b/tests/mock_response.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""Utility code for tests."""
+
+__author__ = 'Jens Finkhaeuser'
+__copyright__ = 'Copyright (c) 2020 Jens Finkhaeuser'
+__license__ = 'MIT +no-false-attribs'
+__all__ = ()
+
+import pytest
+
+class MockResponse(object):
+  """
+  Minimally imitate a response object from the requests library.
+
+  Implements all that's required for prance.util.url
+  """
+
+  def __init__(self, *args, **kwargs):
+    self.ok = kwargs.get('is_ok', True)
+    self.headers = kwargs.get('headers', { 'content-type': 'text/plain' })
+    self.text = kwargs.get('text', '')
+
+# The petstore.yaml file served at
+# http://finkhaeuser.de/projects/prance/petstore.yaml
+PETSTORE_YAML = '''swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+'''
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,6 +156,7 @@ def test_compile_output(runner):
 
 
 @pytest.mark.skipif(none_of('click'), reason = 'Click does not exist')
+@pytest.mark.requires_network()
 def test_convert_defaults(runner):
   from prance import cli
 
@@ -172,6 +173,7 @@ def test_convert_defaults(runner):
 
 
 @pytest.mark.skipif(none_of('click'), reason = 'Click does not exist')
+@pytest.mark.requires_network()
 def test_convert_output(runner):
   from prance import cli
 

--- a/tests/test_resolving_parser.py
+++ b/tests/test_resolving_parser.py
@@ -7,11 +7,17 @@ __license__ = 'MIT +no-false-attribs'
 __all__ = ()
 
 import pytest
+from unittest.mock import patch
 
 from prance import ResolvingParser
 from prance import ValidationError
 
 from . import none_of
+
+def mock_get_petstore(*args, **kwargs):
+  from .mock_response import MockResponse, PETSTORE_YAML
+  return MockResponse(text = PETSTORE_YAML)
+
 
 @pytest.fixture
 def petstore_parser():
@@ -19,7 +25,9 @@ def petstore_parser():
 
 
 @pytest.fixture
-def with_externals_parser():
+@patch('requests.get')
+def with_externals_parser(mock_get):
+  mock_get.side_effect = mock_get_petstore
   return ResolvingParser('tests/specs/with_externals.yaml')
 
 

--- a/tests/test_util_url.py
+++ b/tests/test_util_url.py
@@ -178,6 +178,7 @@ def test_fetch_url_text_cached():
   assert id(content1) == id(content2)
 
 
+@pytest.mark.requires_network()
 def test_fetch_url_http():
   exturl = 'http://finkhaeuser.de/projects/prance/petstore.yaml'\
     '#/definitions/Pet'

--- a/tests/test_zzz_specs.py
+++ b/tests/test_zzz_specs.py
@@ -56,7 +56,6 @@ def iter_entries(parser, backend, version, file_format, path):
       from prance.util import url  
       absurl = url.absurl(os.path.abspath(full)).geturl()
       code = """
-@pytest.mark.requires_network()
 @pytest.mark.xfail()
 def %s():
   import os

--- a/tests/test_zzz_specs.py
+++ b/tests/test_zzz_specs.py
@@ -56,7 +56,8 @@ def iter_entries(parser, backend, version, file_format, path):
       from prance.util import url  
       absurl = url.absurl(os.path.abspath(full)).geturl()
       code = """
-@pytest.mark.xfail
+@pytest.mark.requires_network()
+@pytest.mark.xfail()
 def %s():
   import os
   cur = os.getcwd()


### PR DESCRIPTION
Fixes #46.

Changes proposed in this PR:
- Add `requires_network` mark to tests requiring the network. We can then run tests with `pytest -m "no requires_network"`.
- Mock some other requests in tests.

@jfinkhaeuser
