### PR TITLE
Fix syntax warning over comparison of literals using is.

### DIFF
--- a/tests/test_util_path.py
+++ b/tests/test_util_path.py
@@ -53,7 +53,7 @@ def test_get_value_no_default():
   result = 666
   with pytest.raises(TypeError):
     result = path_get(value, ('foo', 'bar'))
-  assert result is 666
+  assert result == 666
 
   # However, we can resolve zero length paths
   result = path_get(value, ())


### PR DESCRIPTION
Fixes #67 

Changes proposed in this PR:
- Fix syntax warning using == instead of "is" in Python 3.8

@jfinkhaeuser
