### PR TITLE
misc - remove deprecation warning from semver

### DIFF
--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -177,7 +177,7 @@ class BaseParser(mixins.YAMLMixin, mixins.JSONMixin, object):
     self.version_name = prefix
     self.version_parsed = version
     import semver
-    self.semver = semver.format_version(*version)
+    self.semver = str(semver.VersionInfo(*version))
 
     stringified = self.semver
     if prefix == BaseParser.SPEC_VERSION_2_PREFIX:


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
-
change __init__py as per semver to remove depreciation warning

@jfinkhaeuser
