### PR TITLE
Issue 77 - Add Translation Feature

### DIFF
--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -293,5 +293,6 @@ class ResolvingParser(BaseParser):
       )
     resolver.resolve_references()
     self.specification = resolver.specs
+    
     # Now validate - the BaseParser knows the specifics
     BaseParser._validate(self)

--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -293,6 +293,5 @@ class ResolvingParser(BaseParser):
       )
     resolver.resolve_references()
     self.specification = resolver.specs
-    self.specification["components"]["schemas"].update(resolver.soft_derefence_objs)
     # Now validate - the BaseParser knows the specifics
     BaseParser._validate(self)

--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -282,7 +282,7 @@ class ResolvingParser(BaseParser):
     # We therefore use our own resolver first, and validate later.
     from .util.resolver import RefResolver
     forward_arg_names = ('encoding', 'recursion_limit',
-            'recursion_limit_handler', 'resolve_types')
+            'recursion_limit_handler', 'resolve_types', 'resolve_method')
     forward_args = {
       k: v for (k, v) in self.options.items() if k in forward_arg_names
     }

--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -293,6 +293,6 @@ class ResolvingParser(BaseParser):
       )
     resolver.resolve_references()
     self.specification = resolver.specs
-
+    self.specification["components"]["schemas"].update(resolver.soft_derefence_objs)
     # Now validate - the BaseParser knows the specifics
     BaseParser._validate(self)

--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -293,6 +293,6 @@ class ResolvingParser(BaseParser):
       )
     resolver.resolve_references()
     self.specification = resolver.specs
-    
+
     # Now validate - the BaseParser knows the specifics
     BaseParser._validate(self)

--- a/prance/util/iterators.py
+++ b/prance/util/iterators.py
@@ -85,5 +85,4 @@ def reference_iterator(specs, path = ()):
       continue
     key = item_path[-1]
     if key == '$ref':
-      # print("key", key, "item", item, "item_path", item_path[:-1])
       yield key, item, item_path[:-1]

--- a/prance/util/iterators.py
+++ b/prance/util/iterators.py
@@ -85,4 +85,5 @@ def reference_iterator(specs, path = ()):
       continue
     key = item_path[-1]
     if key == '$ref':
+      # print("key", key, "item", item, "item_path", item_path[:-1])
       yield key, item, item_path[:-1]

--- a/prance/util/resolver.py
+++ b/prance/util/resolver.py
@@ -71,6 +71,9 @@ class RefResolver(object):
         detect_encoding is used to determine the encoding.
     :param int resolve_types: [optional] Specify which types of references to
         resolve. Defaults to RESOLVE_ALL.
+    :param int resolve_method: [optional] Specify whether to translate external
+        references in components/schemas or dereference in place. Defaults
+        to TRANSLATE_DEFAULT.
     """
     import copy
     self.specs = copy.deepcopy(specs)

--- a/prance/util/resolver.py
+++ b/prance/util/resolver.py
@@ -127,8 +127,10 @@ class RefResolver(object):
     for _, refstring, item_path in reference_iterator(partial):
       # Split the reference string into parsed URL and object path
       ref_url, obj_path = _url.split_url_reference(base_url, refstring)
+
       translate = self.__resolve_method == TRANSLATE_EXTERNAL and self.parsed_url.path != ref_url.path
-      if not translate and self._skip_reference(base_url, ref_url):
+
+      if self._skip_reference(base_url, ref_url):
         continue
 
       # The reference path is the url resource and object path

--- a/prance/util/resolver.py
+++ b/prance/util/resolver.py
@@ -111,9 +111,7 @@ class RefResolver(object):
     for _, refstring, item_path in reference_iterator(partial):
       # Split the reference string into parsed URL and object path
       ref_url, obj_path = _url.split_url_reference(base_url, refstring)
-      # print("ref_url", ref_url.path, "obj_path", obj_path, "ref_string", refstring)
-      # if base_url.path != self.parsed_url.path:
-      #   print("INTERNAL FILE REF")
+
       if self._skip_reference(base_url, ref_url):
         continue
 
@@ -140,19 +138,14 @@ class RefResolver(object):
 
       # First yield parent
       if not self.__resolve_types & RESOLVE_INTERNAL and base_url.path != self.parsed_url.path:
-        # dref_url = ref_url.path.split("/")[-1]+"/"+"/".join(obj_path[1:])
         dref_url = ref_url.path.split("/")[-1]+"_"+"_".join(obj_path[1:])
-        # base_url.path.split("/")[-1]+"#"+"/".join(obj_path)
         self.soft_derefence_objs[dref_url] = ref_value
-        # print("base_url", "#/"+dref_url, full_path, type(ref_value))
         yield full_path, {"$ref": "#/components/schemas/"+dref_url}
-        # yield tuple(obj_path), ref_value
       else:
         yield full_path, ref_value
 
   def _skip_reference(self, base_url, ref_url):
     """Return whether the URL should not be dereferenced."""
-    # print("REF URL SCHEME", ref_url.scheme)
     if ref_url.scheme.startswith('http'):
       return (self.__resolve_types & RESOLVE_HTTP) == 0
     elif ref_url.scheme == 'file':
@@ -184,12 +177,12 @@ class RefResolver(object):
     # In order to start dereferencing anything in the referenced URL, we have
     # to read and parse it, of course.
     contents = _url.fetch_url(ref_url, self.__reference_cache, self.__encoding)
+
     # In this inner parser's specification, we can now look for the referenced
     # object.
     value = contents
     if len(obj_path) != 0:
       from prance.util.path import path_get
-      # print("obj_path", obj_path)
       try:
         value = path_get(value, obj_path)
       except (KeyError, IndexError, TypeError) as ex:
@@ -202,8 +195,8 @@ class RefResolver(object):
 
     # Now resolve partial specs
     value = self._resolve_partial(ref_url, value, recursions)
+
     # That's it!
-    # print(value)
     return value
 
   def _resolve_partial(self, base_url, partial, recursions):
@@ -220,6 +213,7 @@ class RefResolver(object):
     # sorting paths by path length.
     changes = dict(tuple(self._dereferencing_iterator(base_url, partial, (),
         recursions)))
+
     paths = sorted(changes.keys(), key = len)
 
     # With the paths sorted, set them to the resolved values.
@@ -229,7 +223,6 @@ class RefResolver(object):
       if len(path) == 0:
         partial = value
       else:
-        # print("partial_path", path)
         path_set(partial, list(path), value, create = True)
 
     return partial

--- a/tests/test_util_resolver.py
+++ b/tests/test_util_resolver.py
@@ -559,3 +559,29 @@ def test_issue_77_translate_external_refs_internal():
   # File reference url is updated as well
   val = path_get(res.specs, ('paths', '/endpoint', 'post', 'requestBody', '$ref'))
   assert val == '#/components/schemas/_schemas.json_Body'
+
+
+@pytest.mark.skipif(none_of('openapi-spec-validator'), reason='Missing backends')
+def test_issue_77_internal_refs_unresolved():
+  specs = ''
+  with open('tests/specs/issue_78/openapi.json', 'r') as fh:
+    specs = fh.read()
+
+  from prance.util import formats
+  specs = formats.parse_spec(specs, 'openapi.json')
+
+  res = resolver.RefResolver(specs,
+      fs.abspath('openapi.json'),
+      resolve_types = resolver.RESOLVE_FILES,
+      resolve_method= resolver.TRANSLATE_EXTERNAL
+      )
+  res.resolve_references()
+
+  from prance.util.path import path_get
+  val = path_get(res.specs, ('components', 'schemas'))
+
+  # File reference resolved
+  assert '_schemas.json_Body' in val
+
+  # Internal file reference not resolved
+  assert '_schemas.json_Something' not in val

--- a/tests/test_util_resolver.py
+++ b/tests/test_util_resolver.py
@@ -494,3 +494,68 @@ def test_issue_78_resolve_internal_bug():
   assert 'application/json' in val
   # Internal reference within file is NOT resolved
   assert '$ref' in val['application/json']
+
+
+
+@pytest.mark.skipif(none_of('openapi-spec-validator'), reason='Missing backends')
+def test_issue_77_translate_external():
+  specs = ''
+  with open('tests/specs/issue_78/openapi.json', 'r') as fh:
+    specs = fh.read()
+
+  from prance.util import formats
+  specs = formats.parse_spec(specs, 'openapi.json')
+
+  res = resolver.RefResolver(specs,
+      fs.abspath('openapi.json'),
+      resolve_types = resolver.RESOLVE_FILES,
+      resolve_method= resolver.TRANSLATE_EXTERNAL
+      )
+  res.resolve_references()
+
+  from prance.util.path import path_get
+  val = path_get(res.specs, ('components', 'schemas', '_schemas.json_Body'))
+
+  # Reference to file is translated in components/schemas
+  assert 'content' in val
+  assert 'application/json' in val['content']
+
+  # Reference url is updated
+  val = path_get(res.specs, ('paths', '/endpoint', 'post', 'requestBody', '$ref'))
+  assert val == '#/components/schemas/_schemas.json_Body'
+
+
+
+@pytest.mark.skipif(none_of('openapi-spec-validator'), reason='Missing backends')
+def test_issue_77_translate_external_refs_internal():
+  specs = ''
+  with open('tests/specs/issue_78/openapi.json', 'r') as fh:
+    specs = fh.read()
+
+  from prance.util import formats
+  specs = formats.parse_spec(specs, 'openapi.json')
+
+  res = resolver.RefResolver(specs,
+      fs.abspath('openapi.json'),
+      resolve_types = resolver.RESOLVE_FILES | resolver.RESOLVE_INTERNAL,
+      resolve_method= resolver.TRANSLATE_EXTERNAL
+      )
+  res.resolve_references()
+
+  from prance.util.path import path_get
+  val = path_get(res.specs, ('components', 'schemas', '_schemas.json_Body'))
+
+  # Reference to file is translated in components/schemas
+  assert 'content' in val
+  assert 'application/json' in val['content']
+
+  # Internal Reference links updated
+  assert '#/components/schemas/_schemas.json_Something' == val['content']['application/json']['$ref']
+
+  # Internal references is copied to componnents/schemas seperately
+  val = path_get(res.specs, ('components', 'schemas', '_schemas.json_Something'))
+  assert 'type' in val
+
+  # File reference url is updated as well
+  val = path_get(res.specs, ('paths', '/endpoint', 'post', 'requestBody', '$ref'))
+  assert val == '#/components/schemas/_schemas.json_Body'


### PR DESCRIPTION
Fixes #77.

Changes proposed in this PR:
- Introduces a new parameter called `resolve_method`
- When `resolve_method` is set to `TRANSLATE_EXTERNAL`, it copies the external dereferenced object over to `components/schemas`

### Example ###
OpenAPI specification
```
{
  "openapi": "3.0.0",
  "info": {
    "title": "Test API",
    "version": "1"
  },
  "paths": {
    "/endpoint": {
      "post": {
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {"$ref": "_schemas.json#/$defs/Parameter"}
            }
          }
        },
        "responses": {}
      }
    }
  }
}
```
External file with schema definitions.
```
   {
     "$id": "_schemas.json",
     "$schemas": "https://json-schema.org/draft/2019-09/schema#",
     "$defs": {
       "Something": {
         "type": "object"
       },
       "Parameter": {
         "properties": {
           "something": {
             "$ref": "#/$defs/Something"
           }
         }
       }
     }
   }
```
Using `RESOLVE_FILE | RESOLVE_INTERNAL` and `resolve_method=TRANSLATE_EXTERNAL` this becomes:
```
{
  "openapi":"3.0.0",
  "info":{
    "title":"Test API",
    "version":"1"
  },
  "paths":{
    "/endpoint":{
      "post":{
        "requestBody":{
          "$ref":"#/components/schemas/_schemas.json_Body"
        },
        "responses":{
          
        }
      }
    }
  },
  "components":{
    "schemas":{
      "_schemas.json_Something":{
        "type":"object"
      },
      "_schemas.json_Body":{
        "content":{
          "application/json":{
            "$ref":"#/components/schemas/_schemas.json_Something"
          }
        }
      }
    }
  }
}
```


@jfinkhaeuser
