### PR TITLE
prepare release 26.07.19.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,37 @@
+Prance 26.07.19.0
+=================
+
+Features
+--------
+
+- Add ``--allow-recursion`` CLI flag to ``validate`` and ``compile`` commands,
+  allowing specs with self-referencing ``$ref`` (e.g. recursive types like
+  linked lists or trees) to be processed without raising ``ResolutionError``. (#124)
+- Speed up reference resolution with pure Python optimizations:
+  structural sharing for O(N) chained ``$ref`` resolution (was O(N^2)),
+  resolved-reference caching, optimized iterators and path functions,
+  optional ``orjson`` fast deepcopy (``prance[fast]``),
+  ``keep_ref_on_recursion`` handler to preserve ``$ref`` on recursion,
+  ``materialize=True`` option for independent subtree copies,
+  and a fix for ``path_get`` returning ``defaultvalue`` for falsy values. (#169)
+- Add Python 3.14 support to classifiers, CI, and tox
+
+
+Misc
+----
+
+- Fix sphinx version constraint to <8.2 as 8.2+ requires Python 3.11+
+- Migrate project metadata to pyproject.toml and convert dev dependencies to PEP 735 dependency group
+- Remove obsolete requirements files and appveyor.yml, update docs with modern installation instructions
+- Update GitHub Actions to use latest action versions: checkout@v4, setup-python@v5
+- Update build dependencies: setuptools to >80, setuptools_scm to >9
+- Update core dependencies: ruamel.yaml to 0.18.16, requests to 2.32.5, packaging to 25.0
+- Update dev dependencies: tox to 4.32.0, pytest to 9.0.1, pytest-cov to 7.0.0, sphinx to 8.2.3, towncrier to 25.8.0, click to 8.3.0
+- Update pre-commit configuration to use --py310-plus for pyupgrade and reorder-python-imports
+- Use dependency groups in tox configuration instead of manually specifying deps
+- Use pip --group flag to install dev dependency group in CI
+
+
 Prance 25.04.08.0
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,8 @@ Misc
 - Update GitHub Actions to use latest action versions: checkout@v4, setup-python@v5
 - Update build dependencies: setuptools to >80, setuptools_scm to >9
 - Update core dependencies: ruamel.yaml to 0.18.16, requests to 2.32.5, packaging to 25.0
-- Update dev dependencies: tox to 4.32.0, pytest to 9.0.1, pytest-cov to 7.0.0, sphinx to 8.2.3, towncrier to 25.8.0, click to 8.3.0
+- Update dev dependencies: tox to 4.32.0, pytest to 9.0.1, pytest-cov to 7.0.0, towncrier to 25.8.0
+- Update optional CLI dependency: click to 8.3.0
 - Update pre-commit configuration to use --py310-plus for pyupgrade and reorder-python-imports
 - Use dependency groups in tox configuration instead of manually specifying deps
 - Use pip --group flag to install dev dependency group in CI

--- a/changelog.d/+build_deps.misc.rst
+++ b/changelog.d/+build_deps.misc.rst
@@ -1,1 +1,0 @@
-Update build dependencies: setuptools to >80, setuptools_scm to >9

--- a/changelog.d/+ci_dep_group.misc.rst
+++ b/changelog.d/+ci_dep_group.misc.rst
@@ -1,1 +1,0 @@
-Use pip --group flag to install dev dependency group in CI

--- a/changelog.d/+cleanup.misc.rst
+++ b/changelog.d/+cleanup.misc.rst
@@ -1,1 +1,0 @@
-Remove obsolete requirements files and appveyor.yml, update docs with modern installation instructions

--- a/changelog.d/+core_deps.misc.rst
+++ b/changelog.d/+core_deps.misc.rst
@@ -1,1 +1,0 @@
-Update core dependencies: ruamel.yaml to 0.18.16, requests to 2.32.5, packaging to 25.0

--- a/changelog.d/+dev_deps.misc.rst
+++ b/changelog.d/+dev_deps.misc.rst
@@ -1,1 +1,0 @@
-Update dev dependencies: tox to 4.32.0, pytest to 9.0.1, pytest-cov to 7.0.0, sphinx to 8.2.3, towncrier to 25.8.0, click to 8.3.0

--- a/changelog.d/+github_actions.misc.rst
+++ b/changelog.d/+github_actions.misc.rst
@@ -1,1 +1,0 @@
-Update GitHub Actions to use latest action versions: checkout@v4, setup-python@v5

--- a/changelog.d/+precommit.misc.rst
+++ b/changelog.d/+precommit.misc.rst
@@ -1,1 +1,0 @@
-Update pre-commit configuration to use --py310-plus for pyupgrade and reorder-python-imports

--- a/changelog.d/+pyproject_migration.misc.rst
+++ b/changelog.d/+pyproject_migration.misc.rst
@@ -1,1 +1,0 @@
-Migrate project metadata to pyproject.toml and convert dev dependencies to PEP 735 dependency group

--- a/changelog.d/+python314.feature.rst
+++ b/changelog.d/+python314.feature.rst
@@ -1,1 +1,0 @@
-Add Python 3.14 support to classifiers, CI, and tox

--- a/changelog.d/+sphinx_fix.misc.rst
+++ b/changelog.d/+sphinx_fix.misc.rst
@@ -1,1 +1,0 @@
-Fix sphinx version constraint to <8.2 as 8.2+ requires Python 3.11+

--- a/changelog.d/+tox_groups.misc.rst
+++ b/changelog.d/+tox_groups.misc.rst
@@ -1,1 +1,0 @@
-Use dependency groups in tox configuration instead of manually specifying deps

--- a/changelog.d/124.feature.rst
+++ b/changelog.d/124.feature.rst
@@ -1,3 +1,0 @@
-Add ``--allow-recursion`` CLI flag to ``validate`` and ``compile`` commands,
-allowing specs with self-referencing ``$ref`` (e.g. recursive types like
-linked lists or trees) to be processed without raising ``ResolutionError``.

--- a/changelog.d/169.feature.rst
+++ b/changelog.d/169.feature.rst
@@ -1,7 +1,0 @@
-Speed up reference resolution with pure Python optimizations:
-structural sharing for O(N) chained ``$ref`` resolution (was O(N^2)),
-resolved-reference caching, optimized iterators and path functions,
-optional ``orjson`` fast deepcopy (``prance[fast]``),
-``keep_ref_on_recursion`` handler to preserve ``$ref`` on recursion,
-``materialize=True`` option for independent subtree copies,
-and a fix for ``path_get`` returning ``defaultvalue`` for falsy values.


### PR DESCRIPTION
## Summary
- Fold towncrier fragments into `CHANGES.rst` for CalVer **26.07.19.0**
- Includes resolver speedups (#169), `--allow-recursion` (#124), Python 3.14, and packaging modernization

## After merge
1. Tag `v26.07.19.0` on the merge commit and push the tag
2. Confirm CI `deploy_pypi` publishes `26.7.19.0` to PyPI
3. Optionally close/comment related issues #124 / #158

## Test plan
- [ ] Review changelog section for accuracy
- [ ] Confirm CI is green on this PR
- [ ] After merge: push tag and verify PyPI


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Prepare the 26.07.19.0 release by consolidating towncrier fragment entries into the main changelog and cleaning up obsolete fragment files.

Documentation:
- Update CHANGES.rst with the aggregated release notes for version 26.07.19.0, including resolver improvements, new flags, Python 3.14 support, and packaging updates.

Chores:
- Remove towncrier fragment files from changelog.d now that their contents have been folded into the main changelog for the 26.07.19.0 release.