### PR TITLE
Document spec_string; accept stdin on validate -

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,24 @@ URLs can also be parsed:
 
     parser = ResolvingParser('http://petstore.swagger.io/v2/swagger.json')
 
+Specs already held in memory can be validated via ``spec_string`` (mutually
+exclusive with a path or URL):
+
+.. code:: python
+
+    from prance import BaseParser
+
+    parser = BaseParser(spec_string=openapi_yaml_or_json_text)
+    parser.valid  # True if the backend accepted the spec
+
+From the CLI, pass ``-`` to read a spec from stdin (Click's usual
+dash-means-stdin convention):
+
+.. code:: bash
+
+    $ cat path/to/swagger.yml | prance validate -
+    $ prance validate - < path/to/swagger.yml
+
 Largely, that's it. There is a whole slew of utility code that you may
 or may not find useful, too. Look at the `full documentation
 <https://prance.readthedocs.io/en/latest/#api-modules>`__ for details.

--- a/changelog.d/157.feature.rst
+++ b/changelog.d/157.feature.rst
@@ -1,0 +1,2 @@
+Document ``spec_string`` for in-memory validation and accept ``-`` on
+``prance validate`` to read a spec from stdin. (#157)

--- a/prance/cli.py
+++ b/prance/cli.py
@@ -24,6 +24,43 @@ def __write_to_file(filename, specs):  # noqa: N802
     fs.write_file(filename, contents)
 
 
+def __parser_kwargs(  # noqa: N802
+    resolve: bool,
+    backend: str,
+    strict: bool,
+    encoding: str | None,
+    allow_recursion: bool = False,
+) -> dict:
+    """Build common parser kwargs and echo resolve-related messages."""
+    kwargs: dict = dict(lazy=True, backend=backend, strict=strict, encoding=encoding)
+    if resolve:
+        click.echo(" -> Resolving external references.")
+        if allow_recursion:
+            from prance.util.resolver import keep_ref_on_recursion
+
+            kwargs["recursion_limit_handler"] = keep_ref_on_recursion
+            click.echo(" -> Allowing recursive references (will be kept as $ref).")
+    else:
+        click.echo(" -> Not resolving external references.")
+    return kwargs
+
+
+def __make_parser(  # noqa: N802
+    *,
+    url: str | None = None,
+    spec_string: str | None = None,
+    resolve: bool,
+    backend: str,
+    strict: bool,
+    encoding: str | None,
+    allow_recursion: bool = False,
+):
+    """Return a BaseParser or ResolvingParser for a URL or in-memory spec."""
+    kwargs = __parser_kwargs(resolve, backend, strict, encoding, allow_recursion)
+    klass = prance.ResolvingParser if resolve else prance.BaseParser
+    return klass(url=url, spec_string=spec_string, **kwargs)
+
+
 def __parser_for_url(  # noqa: N802
     url: str,
     resolve: bool,
@@ -45,28 +82,37 @@ def __parser_for_url(  # noqa: N802
     if os.path.exists(fs.from_posix(fsurl)):
         url = fsurl
 
-    # Create parser to use
-    parser = None
-    if resolve:
-        click.echo(" -> Resolving external references.")
-        kwargs: dict = dict(
-            lazy=True, backend=backend, strict=strict, encoding=encoding
-        )
-        if allow_recursion:
-            from prance.util.resolver import keep_ref_on_recursion
-
-            kwargs["recursion_limit_handler"] = keep_ref_on_recursion
-            click.echo(" -> Allowing recursive references (will be kept as $ref).")
-        parser = prance.ResolvingParser(url, **kwargs)
-    else:
-        click.echo(" -> Not resolving external references.")
-        parser = prance.BaseParser(
-            url, lazy=True, backend=backend, strict=strict, encoding=encoding
-        )
-
-    # XXX maybe enable this in debug mode or something.
-    # click.echo(' -> Using backend: {0.backend}'.format(parser))
+    parser = __make_parser(
+        url=url,
+        resolve=resolve,
+        backend=backend,
+        strict=strict,
+        encoding=encoding,
+        allow_recursion=allow_recursion,
+    )
     return parser, formatted
+
+
+def __parser_for_stdin(  # noqa: N802
+    resolve: bool,
+    backend: str,
+    strict: bool,
+    encoding: str | None,
+    allow_recursion: bool = False,
+) -> tuple:
+    """Return a parser instance for a spec read from stdin (``-``)."""
+    click.echo('Processing "-" (stdin)...')
+    stream = click.get_text_stream("stdin", encoding=encoding)
+    spec_string = stream.read()
+    parser = __make_parser(
+        spec_string=spec_string,
+        resolve=resolve,
+        backend=backend,
+        strict=strict,
+        encoding=encoding,
+        allow_recursion=allow_recursion,
+    )
+    return parser, "-"
 
 
 def __validate(parser, name):  # noqa: N802
@@ -187,13 +233,16 @@ def backend_options(ctx, resolve, backend, strict, encoding, allow_recursion):
 )
 @click.argument(
     "urls",
-    type=click.Path(exists=False),
+    type=click.Path(exists=False, allow_dash=True),
     nargs=-1,
 )
 @click.pass_context
 def validate(ctx, output_file, urls):
     """
     Validate the given spec or specs.
+
+    Pass ``-`` to read a single spec from stdin (same as Click's usual
+    dash-means-stdin convention).
 
     If the --resolve option is set, references will be resolved before
     validation.
@@ -213,18 +262,32 @@ def validate(ctx, output_file, urls):
         raise click.UsageError(
             "If --output-file is given, only one input URL " "is allowed!"
         )
+    if urls.count("-") > 1:
+        raise click.UsageError("stdin (-) can only be used once.")
+    if "-" in urls and len(urls) > 1:
+        raise click.UsageError(
+            "stdin (-) cannot be combined with other input URLs or paths."
+        )
 
     # Process files
     for url in urls:
-        # Create parser to use
-        parser, name = __parser_for_url(
-            url,
-            ctx.obj["resolve"],
-            ctx.obj["backend"],
-            ctx.obj["strict"],
-            ctx.obj["encoding"],
-            ctx.obj["allow_recursion"],
-        )
+        if url == "-":
+            parser, name = __parser_for_stdin(
+                ctx.obj["resolve"],
+                ctx.obj["backend"],
+                ctx.obj["strict"],
+                ctx.obj["encoding"],
+                ctx.obj["allow_recursion"],
+            )
+        else:
+            parser, name = __parser_for_url(
+                url,
+                ctx.obj["resolve"],
+                ctx.obj["backend"],
+                ctx.obj["strict"],
+                ctx.obj["encoding"],
+                ctx.obj["allow_recursion"],
+            )
 
         # Try parsing
         __validate(parser, name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,30 @@ def test_validate_output(runner):
 
 
 @pytest.mark.skipif(none_of("click"), reason="Click does not exist")
+def test_validate_from_stdin(runner):
+    from prance import cli
+
+    with open("tests/specs/petstore.yaml", encoding="utf-8") as f:
+        content = f.read()
+
+    result = runner.invoke(cli.validate, ["-"], input=content)
+    assert result.exit_code == 0
+    assert 'Processing "-" (stdin)...' in result.output
+    assert "Validates OK as Swagger/OpenAPI 2.0!" in result.output
+
+
+@pytest.mark.skipif(none_of("click"), reason="Click does not exist")
+def test_validate_stdin_cannot_combine_with_paths(runner):
+    from prance import cli
+
+    result = runner.invoke(
+        cli.validate, ["-", "tests/specs/petstore.yaml"], input="openapi: 3.0.0\n"
+    )
+    assert result.exit_code == 2
+    assert "cannot be combined" in result.output
+
+
+@pytest.mark.skipif(none_of("click"), reason="Click does not exist")
 def test_validate_recursive_fails_by_default(runner):
     from prance import cli
 


### PR DESCRIPTION
## Summary
- Document Python API `spec_string=` for in-memory validation (already supported)
- CLI: `prance validate -` reads a spec from stdin via Click (`Path(allow_dash=True)` + `get_text_stream("stdin")`)
- Reject combining `-` with other paths / using `-` more than once

Closes #157

## Test plan
- [ ] `pytest tests/test_cli.py` (includes stdin cases)
- [ ] `echo '...' | prance validate -` / `prance validate - < file.yml`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Enable stdin-based spec validation in the CLI, centralize parser construction for URL and in-memory specs, and document the `spec_string` API and new CLI usage while covering the behavior with tests.

New Features:
- Support validating specs from stdin via the `prance validate -` CLI convention

Enhancements:
- Refactor parser creation into shared helpers to support URL and in-memory spec parsing consistently

Documentation:
- Document the Python API `spec_string` parameter and the CLI dash-means-stdin behavior in the changelog

Tests:
- Add CLI tests for validating specs from stdin and for rejecting combinations of stdin with file paths