### PR TITLE
fix: do not share a default cache between fetch_url calls

### DIFF
--- a/changelog.d/88.bugfix.rst
+++ b/changelog.d/88.bugfix.rst
@@ -1,0 +1,2 @@
+``fetch_url`` and ``fetch_url_text`` no longer share a cache between calls when
+no ``cache`` argument is given. (#88)

--- a/prance/util/url.py
+++ b/prance/util/url.py
@@ -148,7 +148,7 @@ def split_url_reference(base_url, reference):
     return parsed_url, obj_path
 
 
-def fetch_url_text(url, cache={}, encoding=None):
+def fetch_url_text(url, cache=None, encoding=None):
     """
     Fetch the URL.
 
@@ -167,6 +167,9 @@ def fetch_url_text(url, cache={}, encoding=None):
     :return: The resource text of the URL, and the content type.
     :rtype: tuple
     """
+    if cache is None:
+        cache = {}
+
     url_key = "text_" + urlresource(url)
     entry = cache.get(url_key, None)
     if entry is not None:
@@ -215,7 +218,7 @@ def fetch_url_text(url, cache={}, encoding=None):
     return content, content_type
 
 
-def fetch_url(url, cache={}, encoding=None, strict=True):
+def fetch_url(url, cache=None, encoding=None, strict=True):
     """
     Fetch the URL and parse the contents.
 
@@ -230,6 +233,9 @@ def fetch_url(url, cache={}, encoding=None, strict=True):
     :return: The parsed file.
     :rtype: dict
     """
+    if cache is None:
+        cache = {}
+
     # Return from cache, if parsed result is already present.
     url_key = (urlresource(url), strict)
     entry = cache.get(url_key, None)

--- a/tests/test_util_url.py
+++ b/tests/test_util_url.py
@@ -190,6 +190,32 @@ def test_fetch_url_text_cached():
     assert id(content1) == id(content2)
 
 
+def test_fetch_url_not_cached_without_cache_argument(tmp_path):
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("swagger: '2.0'\ninfo:\n  title: first\n")
+
+    content1 = url.fetch_url(url.absurl(str(spec)))
+    assert content1["info"]["title"] == "first"
+
+    spec.write_text("swagger: '2.0'\ninfo:\n  title: second\n")
+
+    content2 = url.fetch_url(url.absurl(str(spec)))
+    assert content2["info"]["title"] == "second"
+
+
+def test_fetch_url_text_not_cached_without_cache_argument(tmp_path):
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("swagger: '2.0'\ninfo:\n  title: first\n")
+
+    content1, _ = url.fetch_url_text(url.absurl(str(spec)))
+    assert "first" in content1
+
+    spec.write_text("swagger: '2.0'\ninfo:\n  title: second\n")
+
+    content2, _ = url.fetch_url_text(url.absurl(str(spec)))
+    assert "second" in content2
+
+
 @pytest.mark.requires_network()
 def test_fetch_url_http():
     exturl = "https://petstore.swagger.io/v2/swagger.yaml" "#/definitions/Pet"


### PR DESCRIPTION
Fixes #88 .

Changes proposed in this PR:
- `fetch_url` and `fetch_url_text` used a mutable default argument (`cache={}`), so the same dict was reused across calls and URL contents were cached process-wide even though the cache is documented as optional; a file changed on disk was never re-read.
- Default `cache` to `None` and create a fresh dict per call when it is not supplied.
- Regression tests for both functions (fetch, rewrite the file, fetch again); they fail on the current code and pass with the fix. Plus a `changelog.d` entry.

## Summary by Sourcery

Prevent URL fetch helpers from sharing a mutable default cache across calls so resources are re-read when no cache is provided.

Bug Fixes:
- Ensure fetch_url and fetch_url_text create a fresh cache when none is passed, avoiding unintended process-wide caching of URL contents.

Documentation:
- Add changelog entry documenting the cache behavior bugfix for URL fetching utilities.

Tests:
- Add regression tests verifying fetch_url and fetch_url_text do not reuse cached content when called without an explicit cache.